### PR TITLE
Add Styling

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 sbyte[,] pawnScores = 
 {
@@ -96,20 +96,25 @@ sbyte[,] EndKingScores =
     {-50,-30,-30,-30}
 };
 
-void PackScoreData()
+void PackScoreData(bool styling = false)
 {
     //Add boards from "index" 0 upwards. Here, the pawn board is "index" 0.
     //That means it will occupy the least significant byte in the packed data.
-    List<sbyte[,]> allScores = new();
-    allScores.Add(pawnScores);
-    allScores.Add(knightScores);
-    allScores.Add(bishopScores);
-    allScores.Add(rookScores);
-    allScores.Add(queenScores);
-    allScores.Add(kingScores);
-    allScores.Add(MiddleKingScores);
-    allScores.Add(EndKingScores);
+    //Simplifiction
+    List<sbyte[,]> allScores = new()
+    {
+        pawnScores,
+        knightScores,
+        bishopScores,
+        rookScores,
+        queenScores,
+        kingScores,
+        MiddleKingScores,
+        EndKingScores
+    };
 
+    //Styling
+    if(styling) Console.WriteLine("static readonly ulong[,] packedScores =\n{");
 
     ulong[,] packedData = new ulong[8,4];
     for(int rank = 0; rank < 8; rank++)
@@ -124,8 +129,16 @@ void PackScoreData()
                 packedData[rank,file] += ((ulong)thisSet[rank,file]) << (8 * set);
             }
         }
-        Console.WriteLine("{{0x{0:X16}, 0x{1:X16}, 0x{2:X16}, 0x{3:X16}}},", packedData[rank,0], packedData[rank,1], packedData[rank,2], packedData[rank,3]);
+
+        //Remove the comma on the last rank
+        if(rank > 6 && styling)
+            Console.WriteLine("    {{0x{0:X16}, 0x{1:X16}, 0x{2:X16}, 0x{3:X16}}}", packedData[rank,0], packedData[rank,1], packedData[rank,2], packedData[rank,3]);
+        else 
+            Console.WriteLine("{0}{{0x{1:X16}, 0x{2:X16}, 0x{3:X16}, 0x{4:X16}}},", styling ? "    " : "", packedData[rank,0], packedData[rank,1], packedData[rank,2], packedData[rank,3]);
     }
+
+    if(styling) Console.WriteLine("};");
 }
 
+//Pass true for *styling*
 PackScoreData();


### PR DESCRIPTION
### Add-Styling:
Added a little output styling for easily copy-pasting.
Pass `true` to `PackScoreData()` as the first argument for output styling.

example output with "styling":
```
static readonly ulong[,] packedScores =
{
    {0xCDE1E1EBFFEBCE00, 0xD7D7D7F5FFF5D800, 0xE1D7D7F5FFF5E200, 0xEBCDCDFAFFF5E200},
    {0xE1E1E1F604F5D80A, 0xEBD7D80009FFEC0A, 0xF5D7D8000A000014, 0xFFCDCE000A00001E},
    {0xE1E1E1F5FAF5E232, 0xF5D7D80000000032, 0x13D7D80500050A32, 0x1DCDCE05000A0F32},
    {0xE1E1E1FAFAF5E205, 0xF5D7D80000050505, 0x1DD7D80500050F0A, 0x27CDCE05000A1419},
    {0xE1EBEBFFFAF5E200, 0xF5E1E20000000000, 0x1DE1E205000A0F00, 0x27D7D805000A1414},
    {0xE1F5F5F5FAF5E205, 0xF5EBEC05000A04FB, 0x13EBEC05000A09F6, 0x1DEBEC05000A0F00},
    {0xE21413F5FAF5D805, 0xE21414000004EC0A, 0x000000050000000A, 0x00000000000004EC},
    {0xCE1413EBFFEBCE00, 0xE21E1DF5FFF5D800, 0xE20A09F5FFF5E200, 0xE1FFFFFB04F5E200}
};
```

You can also pass nothing to get the default output.

### Simplify `allScores` List Creation:
```cs
List<sbyte[,]> allScores = new();
    allScores.Add(pawnScores);
    allScores.Add(knightScores);
    allScores.Add(bishopScores);
    allScores.Add(rookScores);
    allScores.Add(queenScores);
    allScores.Add(kingScores);
    allScores.Add(MiddleKingScores);
    allScores.Add(EndKingScores);
```
to:
```cs
List<sbyte[,]> allScores = new()
{
        pawnScores,
        knightScores,
        bishopScores,
        rookScores,
        queenScores,
        kingScores,
        MiddleKingScores,
        EndKingScores
};
```
*Line **104***